### PR TITLE
Make header names lowercase

### DIFF
--- a/src/win.h
+++ b/src/win.h
@@ -24,9 +24,9 @@
 #pragma warning(push, 1)
 #endif
 
-#include <WS2tcpip.h>
-#include <WinSock2.h>
-#include <Windows.h>
+#include <ws2tcpip.h>
+#include <winsock2.h>
+#include <windows.h>
 
 #ifndef __GNUC__
 #pragma warning(pop)

--- a/src/win.h
+++ b/src/win.h
@@ -24,9 +24,15 @@
 #pragma warning(push, 1)
 #endif
 
+#ifdef __MINGW32__
 #include <ws2tcpip.h>
 #include <winsock2.h>
 #include <windows.h>
+#else
+#include <WS2tcpip.h>
+#include <WinSock2.h>
+#include <Windows.h>
+#endif
 
 #ifndef __GNUC__
 #pragma warning(pop)


### PR DESCRIPTION
Uppercase file names inside `#include <>` will cause compilation errors when cross-compiling from case-sensitive systems: https://github.com/stjepang/smol/issues/138#issuecomment-633725620