### PR TITLE
Handle null events by PostQueuedCompletionStatus

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -167,7 +167,13 @@ static inline int port__feed_events(port_state_t* port_state,
         (IO_STATUS_BLOCK*) iocp_events[i].lpOverlapped;
     struct epoll_event* ev = &epoll_events[epoll_event_count];
 
-    epoll_event_count += sock_feed_event(port_state, io_status_block, ev);
+    if (io_status_block)
+      epoll_event_count += sock_feed_event(port_state, io_status_block, ev);
+    else {
+      ev->events = 0;
+      ev->data.u64 = 0;
+      epoll_event_count += 1;
+    }
   }
 
   return epoll_event_count;


### PR DESCRIPTION
I am calling this:

```cpp
PostQueuedCompletionStatus(wepoll_handle, 0, 0, NULL);
```

in order to wakeup threads blocked on `epoll_wait`. This patch makes wepoll report a null event (event=0, u64=0) instead of crashing.